### PR TITLE
feat(incoming-handler): add hook support

### DIFF
--- a/pkg/incoming-handler/README.md
+++ b/pkg/incoming-handler/README.md
@@ -19,9 +19,13 @@ yarn add incoming-handler
 ## Example usage
 
 ```typescript
-import { Controller, createInstance } from 'incoming-handler'
+import { createInstance } from 'incoming-handler'
+import type { Controller, RequestAdapter, GET, POST, hook } from 'incoming-handler'
 import { fetchThing, saveThing } from './libs/my-example-thing-fetcher'
 
+@hook('beforeRespond', (adapter: RequestAdapter) => {
+  adapter.setHeader('X-Global-Header': 'always inject this')
+})
 class ThingController extends Controller {
   @GET('/thing/:id')
   async getThing({ params }) {
@@ -39,8 +43,9 @@ class ThingController extends Controller {
   }
 }
 
-import { nodeHttpAdapter } from 'incoming-handler/adapter/node'
-const startServer = createInstance({ controllers: [new ThingController()], adapter: nodeHttpAdapter })
+import { nodeHttpAdapter } from 'incoming-handler/adapter-node'
+const controllers = [ new ThingController() ]
+const startServer = createInstance({ controllers, adapter: nodeHttpAdapter })
 
 // If you want to start a local node server:
 startServer({
@@ -49,10 +54,10 @@ startServer({
 })
 
 // or exposing to lambda handler:
-export.handler = instance.getLambdaHandler()
+export.handler = createInstance({ controllers, adapter: lambdaAdapter })
 
 // or implementing a fetch event handler in cloudflare workers:
-addEventListener('fetch', instance.getFetchEventHandler())
+addEventListener('fetch', createInstance({ controllers, adapter: lambdaAdapter }))
 ```
 
 ## TODOs

--- a/pkg/incoming-handler/src/adapters/LambdaAdapter/index.ts
+++ b/pkg/incoming-handler/src/adapters/LambdaAdapter/index.ts
@@ -1,14 +1,13 @@
 import type { Handler, HandlerContext, HandlerEvent } from '@netlify/functions'
-import { Controller } from '../../types'
+import { Controller, ImplementationContext } from '../../types'
 import { requestHandler } from '../../requestHandler'
 import { LambdaAdapter } from './LambdaAdapter'
-import { RouteHandler } from '../..'
 
 export const lambdaAdapter =
-  (controllers: Controller[], routeHandlers: RouteHandler[]) => (): Handler => {
+  (controllers: Controller[], ctx: ImplementationContext) => (): Handler => {
     return async (event: HandlerEvent, context: HandlerContext) => {
       const adapter = new LambdaAdapter(event, context)
-      await requestHandler(controllers, routeHandlers, adapter)
+      await requestHandler(controllers, ctx, adapter)
 
       return adapter.getLambdaResponse()
     }

--- a/pkg/incoming-handler/src/adapters/NodeHttpAdapter/index.ts
+++ b/pkg/incoming-handler/src/adapters/NodeHttpAdapter/index.ts
@@ -1,7 +1,6 @@
 import http, { IncomingMessage, ServerResponse } from 'http'
 import { requestHandler } from '../../requestHandler'
-import { Controller, RouteHandler } from '../../types'
-import { RequestHandlerOptions } from '../../types'
+import { Controller, ImplementationContext, RouteHandler } from '../../types'
 import { NodeHttpAdapter } from './NodeHttpAdapter'
 
 export interface NodeHttpAdapterOptions {
@@ -10,11 +9,11 @@ export interface NodeHttpAdapterOptions {
 }
 
 export const nodeHttpAdapter =
-  (controllers: Controller[], routeHandlers: RouteHandler[]) =>
+  (controllers: Controller[], ctx: ImplementationContext) =>
   ({ host, port }: NodeHttpAdapterOptions) => {
     http
       .createServer(async (req: IncomingMessage, res: ServerResponse) => {
-        return requestHandler(controllers, routeHandlers, new NodeHttpAdapter(req, res))
+        return requestHandler(controllers, ctx, new NodeHttpAdapter(req, res))
       })
       .listen(port, host, () => {
         console.log(`Server is listening on http://${host}:${port}`)

--- a/pkg/incoming-handler/src/adapters/WorkersAdapter/index.ts
+++ b/pkg/incoming-handler/src/adapters/WorkersAdapter/index.ts
@@ -1,17 +1,18 @@
 import { requestHandler } from '../../requestHandler'
-import { Controller, RouteHandler } from '../../types'
+import { Controller, ImplementationContext } from '../../types'
 import { FetchEvent, FetchEventHandler } from './types'
 import { WorkersAdapter } from './WorkersAdapter'
 
 export const workersAdapter =
-  (controllers: Controller[], routeHandlers: RouteHandler[]) =>
+  (controllers: Controller[], ctx: ImplementationContext) =>
   (): FetchEventHandler =>
   (event: FetchEvent) => {
-    event.waitUntil(requestHandler(controllers, routeHandlers, new WorkersAdapter(event)))
+    // TOOD: headers
+    event.waitUntil(requestHandler(controllers, ctx, new WorkersAdapter(event)))
   }
 
 export const functionAdapter =
-  (controllers: Controller[], routeHandlers: RouteHandler[]) => (): FetchEventHandler =>
+  (controllers: Controller[], ctx: ImplementationContext) => (): FetchEventHandler =>
     async function onRequest(context) {
       let rez
       const adapter = new WorkersAdapter({
@@ -22,7 +23,7 @@ export const functionAdapter =
           rez = res
         },
       })
-      await requestHandler(controllers, routeHandlers, adapter)
+      await requestHandler(controllers, ctx, adapter)
 
       return rez
     }

--- a/pkg/incoming-handler/src/createInstance.ts
+++ b/pkg/incoming-handler/src/createInstance.ts
@@ -1,7 +1,8 @@
 import { RequestHandlerOptions } from './types'
-import { getAllRouteHandlers } from './decorators'
+import { getAllHooks, getAllRouteHandlers } from './decorators'
 
 export const createInstance = ({ controllers, adapter }: RequestHandlerOptions) => {
   const routeHandlers = getAllRouteHandlers()
-  return adapter(controllers, routeHandlers)
+  const hooks = getAllHooks()
+  return adapter(controllers, { routeHandlers, hooks })
 }

--- a/pkg/incoming-handler/src/decorators.ts
+++ b/pkg/incoming-handler/src/decorators.ts
@@ -1,15 +1,34 @@
 import { AcceptedMethod } from '.'
 import { parseRoute } from './router'
-import { Method, RouteHandler } from './types'
+import { Method, RouteHandler, Hook } from './types'
 
 const handlers: RouteHandler[] = []
+const hooks: Hook[] = []
 
 export const getAllRouteHandlers = (): RouteHandler[] => {
   return handlers
 }
 
+export const getAllHooks = (): Hook[] => {
+  return hooks
+}
+
 const addHandler = (routeHandler: RouteHandler) => {
   handlers.push(routeHandler)
+}
+
+const addHeaders = (hook: Hook) => {
+  hooks.push(hook)
+}
+
+export const hook = (event: Hook['event'], hook: Hook['hook']): ClassDecorator => {
+  return (target) => {
+    addHeaders({
+      event,
+      proto: target,
+      hook,
+    })
+  }
 }
 
 export const route = (path: string, method: AcceptedMethod = '*'): MethodDecorator => {

--- a/pkg/incoming-handler/src/requestHandler.ts
+++ b/pkg/incoming-handler/src/requestHandler.ts
@@ -1,10 +1,10 @@
 import { RequestAdapter } from './RequestAdapter'
 import { getPathParams, pathMathesRoute } from './router'
-import { RouteHandler, Controller, ActionParams } from './types'
+import { Controller, ActionParams, ImplementationContext, Hook } from './types'
 
 export const requestHandler = async (
   controllers: Controller[],
-  handlers: RouteHandler[],
+  { hooks, routeHandlers: handlers }: ImplementationContext,
   adapter: RequestAdapter,
 ) => {
   const pathname = adapter.getPath()
@@ -18,52 +18,67 @@ export const requestHandler = async (
 
   adapter.setHeader('Content-type', 'application/json')
 
+  await callHooks(hooks, 'beforeRespond', adapter)
+
   const respond = makeResponse(adapter)
 
-  if (!matchedHandler) {
-    return respond(404, 'not found')
-  }
-
-  const { proto, action, route } = matchedHandler
-
-  const controller = controllers.find((controller) => proto === Object.getPrototypeOf(controller))
-
-  if (!controller) {
-    throw new Error('missing controller for path ' + pathname)
-  }
-
-  const values = getPathParams(pathname, route)
-
-  const actionProps: ActionParams = {
-    url: {
-      // these two feel off
-      pathname,
-      query: new URLSearchParams(pathname),
-    },
-    params: values,
-    // IncomingMessage defines this as any string
-    method: requestMethod,
-    body,
-  }
-
-  let data
   try {
-    // TODO better type somehow
-    data = await (controller as any)[action](actionProps)
-  } catch (e) {
-    return respond(500, {
-      error: 'Internal server error',
-    })
-  }
+    if (!matchedHandler) {
+      return respond(404, 'not found')
+    }
 
-  if (!data) {
-    return respond(requestMethod === 'POST' ? 201 : 204, '')
-  }
+    const { proto, action, route } = matchedHandler
 
-  return respond(requestMethod === 'POST' ? 201 : 200, data)
+    const controller = controllers.find((controller) => proto === Object.getPrototypeOf(controller))
+
+    if (!controller) {
+      throw new Error('missing controller for path ' + pathname)
+    }
+
+    const values = getPathParams(pathname, route)
+
+    const actionProps: ActionParams = {
+      url: {
+        // these two feel off
+        pathname,
+        query: new URLSearchParams(pathname),
+      },
+      params: values,
+      // IncomingMessage defines this as any string
+      method: requestMethod,
+      body,
+    }
+
+    let data
+    try {
+      // TODO better type somehow
+      data = await (controller as any)[action](actionProps)
+    } catch (e) {
+      // TODO: hook or something
+      return respond(500, {
+        error: 'Internal server error',
+      })
+    }
+
+    if (!data) {
+      return respond(requestMethod === 'POST' ? 201 : 204, '')
+    }
+
+    return respond(requestMethod === 'POST' ? 201 : 200, data)
+  } finally {
+    await callHooks(hooks, 'afterRespond', adapter)
+  }
 }
 
 const makeResponse = (adapter: RequestAdapter) => (status: number, body: any) => {
   adapter.setStatus(status)
   adapter.sendBody(body ? JSON.stringify(body) : '')
+}
+
+const callHooks = async (hooks: Hook[], targetEvent: Hook['event'], adapter: RequestAdapter) => {
+  // TODO: not doing anything with the target property -- so the hook gets used on every possible
+  // class atm
+  for (const hook of hooks.filter(({ event }) => event === targetEvent)) {
+    await hook.hook(adapter)
+  }
 }

--- a/pkg/incoming-handler/src/types.ts
+++ b/pkg/incoming-handler/src/types.ts
@@ -1,4 +1,11 @@
+import { RequestAdapter } from './RequestAdapter'
 import { RouteValues } from './router'
+
+export interface Hook {
+  proto: Function
+  event: 'beforeRespond' | 'afterRespond'
+  hook: (adapter: RequestAdapter) => Promise<void>
+}
 
 export type Method =
   | 'CONNECT'
@@ -33,10 +40,12 @@ export interface RequestHandlerOptions {
   adapter: RequestAdapterImpl
 }
 
-export type RequestAdapterImpl = (
-  controllers: Controller[],
-  routeHandlers: RouteHandler[],
-) => Function
+export interface ImplementationContext {
+  routeHandlers: RouteHandler[]
+  hooks: Hook[]
+}
+
+export type RequestAdapterImpl = (controllers: Controller[], ctx: ImplementationContext) => Function
 
 export abstract class Controller {}
 


### PR DESCRIPTION
adds the ability to add a hook on class decorators -- currently only global hooks performed either before or after each request is handled 

```
@hook('beforeRespond', (adapter) => { /* something */ })
```